### PR TITLE
Add py-EVM to list of implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Here is [how to contribute](./contributing.md).
     - An Ethereum client that generates the consensus test suite
 * [Pyethereum](https://github.com/ethereum/pyethereum) in Python
     - Another client with probably the best readable EVM implementation
+* [Py-EVM](https://github.com/pipermerriam/py-evm) in Python
+    - An alternate Python implementation designed to be highly configurable and modular.
 * [EthereumJ](https://github.com/ethereum/ethereumj) in Java
     - A client with its own EVM implementation
 * [eth-isabelle](https://github.com/pirapira/eth-isabelle)


### PR DESCRIPTION
### What was wrong

Py-EVM was not listed under the list of implementations.

### How was it fixed.

Added it.  If it was intentionally not included because it is still under development, please feel free to close this issue.

#### Cute animal picture

![kd9kiuv](https://user-images.githubusercontent.com/824194/27651260-f0afa2e2-5bf4-11e7-9423-87b1bbc5fc3f.jpg)
