### PR TITLE
Move stale resources to STALE.md and fix outdated URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Not listed there yet, but in the spirit of [![Awesome](https://cdn.rawgit.com/si
 
 Here is [how to contribute](./contributing.md).
 
+Outdated and archived resources have been moved to [STALE.md](./STALE.md).
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
@@ -19,7 +21,6 @@ Here is [how to contribute](./contributing.md).
 - [Debuggers](#debuggers)
 - [Code Analyzers](#code-analyzers)
 - [Improvement Proposals](#improvement-proposals)
-- [Related Resources](#related-resources)
 - [License of This List](#license-of-this-list)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -53,134 +54,67 @@ Here is [how to contribute](./contributing.md).
 
 * [go-ethereum](https://github.com/ethereum/go-ethereum)
     - A popular Ethereum client with its own EVM implementation ([core/vm](https://github.com/ethereum/go-ethereum/tree/master/core/vm) directory)
-* [Parity](https://github.com/paritytech/parity) in Rust
-    - Another popular Ethereum client with its own EVM implementation ([ethcore](https://github.com/paritytech/parity/tree/master/ethcore) directory)
-* [cpp-ethereum](https://github.com/ethereum/cpp-ethereum)
-    - An Ethereum client that generates the consensus test suite ([libevm/VM.cpp](https://github.com/ethereum/cpp-ethereum/blob/develop/libevm/VM.cpp))
-* [Pyethereum](https://github.com/ethereum/pyethereum) in Python
-    - A mostly deprecated client ([ethereum/vm.py](https://github.com/ethereum/pyethereum/blob/develop/ethereum/vm.py))
-* [Py-EVM](https://github.com/pipermerriam/py-evm) in Python
-    - A Python implementation designed to be highly configurable and modular and compliant with the Ethereum test suite, work is in progress on it to run a full node and develop sharding.
 * [py-ethclient](https://github.com/tokamak-network/py-ethclient) in Python
     - A from-scratch Python execution client with 140+ EVM opcodes, RLPx transport, eth/68 and snap/1 wire protocols, full sync, snap sync, Engine API V1/V2/V3, and JSON-RPC
-* [EthereumJ](https://github.com/ethereum/ethereumj) in Java
-    - A client with its own EVM implementation
 * For more, see
   [here](https://ethereum.org/developers/docs/nodes-and-clients/#execution-clients).
 
 ### Other Implementations
 
-* [SputnikVM](https://github.com/ethereumproject/sputnikvm) in Rust for Ethereum Classic
-    - A standalone EVM featuring [a developer
-      environment](https://github.com/ethereumproject/sputnikvm-dev),
-      a [browser through wasm32-unknown-emscripten
-      target](https://github.com/sorpaas/sputnikvm-in-browser), and for
-      [embedded devices](https://github.com/sorpaas/sputnikvm-on-rux)
-* [Modeling EVM in the K framework](https://github.com/kframework/evm-semantics) ([whitepaper](https://www.ideals.illinois.edu/handle/2142/97207))
-    - An EVM implementation for [K framework](http://www.kframework.org/index.php/Main_Page)
-* [hevm](https://github.com/dapphub/hevm)
-    - An EVM implementation written in Haskell with debugging in mind
-* [eth-isabelle](https://github.com/pirapira/eth-isabelle)
-    - An EVM implementation for theorem provers
-* [Burrow](https://github.com/hyperledger/burrow)
-    - An EVM implementation in Go extended with a native name registry and permissioning layer
-* [Ethereumjs-VM](https://github.com/ethereumjs/ethereumjs-vm)
-    - Implements Ethereum's VM in JS
-* [ruby-ethereum](https://github.com/cryptape/ruby-ethereum)
-    - An EVM implementation in Ruby (passed all tests in [ethereum tests](https://github.com/ethereum/tests/tree/55a18b3ded93bf6083f23ea1f4bf7be4ba973016))
-* [sputter](https://github.com/nervous-systems/sputter)
-    - An EVM implementation in Clojure (so far passes VM tests)
-* [solevm](https://github.com/Ohalo-Ltd/solevm)
-    - An EVM implementation in Solidity
-* [eth-acl2](https://github.com/zchn/eth-acl2)
-    - An EVM implementation in ACL2 (work in progress)
-* [mana](https://github.com/poanetwork/mana/)
-    - An EVM implementation in Elixir (work in progress)
+* [Modeling EVM in the K framework](https://github.com/runtimeverification/evm-semantics) ([whitepaper](https://www.ideals.illinois.edu/items/102260))
+    - An EVM implementation for the [K framework](https://kframework.org/), maintained by Runtime Verification
+* [hevm](https://github.com/ethereum/hevm)
+    - An EVM implementation written in Haskell, focused on debugging and formal verification
+* [Ethereumjs-VM](https://github.com/ethereumjs/ethereumjs-monorepo)
+    - Implements Ethereum's VM in JS (part of the ethereumjs monorepo)
 
 ## Programming Languages that Compile into EVM
 
 * [Solidity](https://github.com/ethereum/solidity)
     - The most popular programming language for Ethereum contracts
     - [Awesome Solidity](https://github.com/bkrem/awesome-solidity)
-    - The LLL compiler is also in the same repository
-* [Vyper](https://github.com/ethereum/vyper)
+* [Vyper](https://github.com/vyperlang/vyper)
     - A language with overflow-checking, numeric units but without unlimited loops
-* [Pyramid Scheme](https://github.com/MichaelBurge/pyramid-scheme) (experimental)
-    - A Scheme compiler into EVM that follows the [SICP compilation approach](https://mitpress.mit.edu/sicp/full-text/book/book-Z-H-35.html#%_sec_5.5)
-    - [ceagle](https://github.com/MichaelBurge/ceagle) compiles C into Pyramid Scheme
-* [Flint](https://github.com/franklinsch/flint)
-    - A language with several security features: e.g. asset types with a restricted set of atomic operations
-* [LLLL](https://github.com/mmalvarez/eth-isabelle/blob/master/example/LLLL.thy)
-    - An LLL-like compiler being implemented in Isabelle/HOL
-* [HAseembly-evm](https://github.com/takenobu-hs/haskell-ethereum-assembly)
-    - An EVM assembly implemented as a Haskell DSL
-* [Bamboo](https://github.com/pirapira/bamboo) (experimental)
-    - A language without loops but with explicit constructor invocation at the end of every call
 
 ### Programming Languages that Compile zk-SNARK Circuits and Proofs
 
-* [Zokrates](https://github.com/JacobEberhardt/ZoKrates)
+* [Zokrates](https://github.com/Zokrates/ZoKrates)
     - A toolbox for zkSNARKs on Ethereum
-    - [a third-party tutorial](https://github.com/jstoxrocky/zksnarks_example)
 * [snarky](https://github.com/o1-labs/snarky)
     - An OCaml front-end for writing R1CS SNARKs (parametrized over the backend SNARK libraries)
     - Shallowly embedded DSL that can be compiled into SNARK circuits
     - The verifier is an OCaml function, so some more work is necessary before using it on Ethereum
-* [jsnark](https://github.com/akosba/jsnark)
-    - A Java front-end for writing R1CS SNARKs 
 
 ## Debuggers
 
-* [REMIX](https://github.com/ethereum/remix)
+* [Remix IDE](https://github.com/ethereum/remix-project)
     - An IDE containing an EVM code debugger
-* [debug\_traceTransaction method](https://github.com/ethereum/go-ethereum/wiki/Management-APIs#debug_tracetransaction)
+* [debug\_traceTransaction method](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug)
     - An instruction-wise trace information provided by go-ethereum
 * [Ethereum Function Signature Database](https://www.4byte.directory/)
     - A database for deciphering `0x165ffd10` into `restart(bytes32,bytes32)`.
 
 ## Code Analyzers
 
-* [Echidna](https://github.com/trailofbits/echidna)
+* [Echidna](https://github.com/crytic/echidna)
     - A fuzzer on EVM that also takes Solidity input
     - Able to fuzz a program with sequences of multiple transactions
 * [MAIAN](https://arxiv.org/abs/1802.06038)
     - An automatic tool that detects trace vulnerabilities (Greedy, Prodigal and Suicidal) with depth-first search of symbolic execution of multiple invocations
-* [Mythril](https://github.com/b-mueller/mythril)
-    - A blockchain exploration tool that indexes all contracts on the network, containing a disassembler, an ABI function detector and a control flow analyzer
-    - Comes with a [--fire-laser option](https://hackernoon.com/crafting-ethereum-exploits-by-laser-fire-1c9acf25af4f)
-    - Powered by [laser-ethereum](https://github.com/b-mueller/laser-ethereum)
-* [porosity](https://github.com/comaeio/porosity)
-    - A reverse enginering tool, a disassembler, an ABI function detector and a decompiler that also highlights vulnerabilities
+* [Mythril](https://github.com/muellerberndt/mythril)
+    - A security analysis tool for EVM bytecode; supports Solidity and Vyper
 * [Manticore](https://github.com/trailofbits/manticore)
-    - A symtolic execution engine that can generate inputs to cover codepaths ([asciicast](https://asciinema.org/a/154012)), which also comes with a Python API
-* [evmdis](https://github.com/arachnid/evmdis)
-    - A disassembler for EVM code
-* [ethersplay](https://github.com/trailofbits/ethersplay)
-    - An EVM plugin for [Binary Ninja](https://binary.ninja/)
-* [Securify](http://securify.ch/)
+    - A symbolic execution engine that can generate inputs to cover codepaths ([asciicast](https://asciinema.org/a/154012)), which also comes with a Python API
+* [Securify](https://github.com/eth-sri/securify2)
     - A tool that strives to achieve no false-negatives
-    - The implementation seems not public as of now
-* [Oyente](https://github.com/melonproject/oyente)
-    - An automatic EVM code analyzer based on symbolic execution and [Z3](https://github.com/Z3Prover/z3) SMT solver
-* [Dr. Y's Ethereum Contract Analyzer](http://dry.yoichihirai.com/)
-    - A symbolic executor for EVM code
 * [L3X](https://github.com/VulnPlanet/l3x)
     - L3X - AI-driven Smart Contract Static Analyzer
-      
 
 ## Improvement Proposals
 
 * [Ethereum Improvement Proposals](https://github.com/ethereum/EIPs)
     - A portal for EVM & Ethereum improvements
     - The soonest changes are listed in the README
-* [EVM 1.5](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-615.md)
-    - A proposal to tame jumps so that a linear-time scan can determine stack layouts
-* [eWASM](https://github.com/ewasm)
-    - A proposal to use a [WebAssembly](http://webassembly.org/) for Ethereum contract execution
-
-## Related Resources
-
-* [Awesome Ethereum](http://awesome-ethereum.com/)
 
 ## License of This List
 

--- a/STALE.md
+++ b/STALE.md
@@ -1,0 +1,101 @@
+# Stale Resources
+
+This file contains resources that were previously listed in the main [README](./README.md) but are now archived, abandoned, or otherwise no longer maintained. They are preserved here for historical reference.
+
+---
+
+## EVM Implementations (Stale)
+
+### Former Main-Network Clients
+
+* [Parity](https://github.com/paritytech/parity) in Rust
+    - Redirects to the archived [openethereum/parity-ethereum](https://github.com/openethereum/parity-ethereum). Parity was superseded by OpenEthereum, which was itself discontinued in 2022.
+* [cpp-ethereum](https://github.com/ethereum/cpp-ethereum)
+    - Redirects to the archived [ethereum/aleth](https://github.com/ethereum/aleth). The C++ client was discontinued.
+* [Pyethereum](https://github.com/ethereum/pyethereum) in Python
+    - Officially archived. Superseded by Py-EVM.
+* [Py-EVM](https://github.com/ethereum/py-evm) in Python
+    - Officially archived. Was designed to be highly configurable and modular.
+* [EthereumJ](https://github.com/ethereum/ethereumj) in Java
+    - Officially archived. Java client abandoned.
+
+### Other Implementations
+
+* [SputnikVM](https://github.com/ethereumproject/sputnikvm) in Rust for Ethereum Classic
+    - Redirects to the abandoned [ETCDEVTeam/sputnikvm](https://github.com/ETCDEVTeam/sputnikvm). The ETCDEV team disbanded. Featured a [developer environment](https://github.com/ethereumproject/sputnikvm-dev), a [browser through wasm32-unknown-emscripten target](https://github.com/sorpaas/sputnikvm-in-browser), and support for [embedded devices](https://github.com/sorpaas/sputnikvm-on-rux).
+* [hevm](https://github.com/dapphub/hevm)
+    - Officially archived. The project was relaunched at [ethereum/hevm](https://github.com/ethereum/hevm).
+* [eth-isabelle](https://github.com/pirapira/eth-isabelle)
+    - An EVM implementation for theorem provers. Abandoned, last active ~2022.
+* [Burrow](https://github.com/hyperledger/burrow)
+    - Redirects to the archived [hyperledger-archives/burrow](https://github.com/hyperledger-archives/burrow). An EVM implementation in Go extended with a native name registry and permissioning layer. Retired by Hyperledger in 2022.
+* [ruby-ethereum](https://github.com/cryptape/ruby-ethereum)
+    - Officially archived. An EVM implementation in Ruby (passed all tests in [ethereum tests](https://github.com/ethereum/tests/tree/55a18b3ded93bf6083f23ea1f4bf7be4ba973016)).
+* [sputter](https://github.com/nervous-systems/sputter)
+    - An EVM implementation in Clojure. Abandoned since ~2019.
+* [solevm](https://github.com/Ohalo-Ltd/solevm)
+    - Officially archived. An EVM implementation in Solidity.
+* [eth-acl2](https://github.com/zchn/eth-acl2)
+    - An EVM implementation in ACL2. Abandoned since ~2022.
+* [mana](https://github.com/mana-ethereum/mana/)
+    - An EVM implementation in Elixir. Repo moved from poanetwork; effectively inactive.
+
+---
+
+## Programming Languages (Stale)
+
+### Languages that Compile into EVM
+
+* [Pyramid Scheme](https://github.com/MichaelBurge/pyramid-scheme) (experimental)
+    - Officially archived. A Scheme compiler into EVM that follows the [SICP compilation approach](https://web.mit.edu/6.001/6.037/sicp.pdf). [ceagle](https://github.com/MichaelBurge/ceagle) compiled C into Pyramid Scheme.
+* [Flint](https://github.com/flintlang/flint)
+    - A language with several security features (e.g. asset types with a restricted set of atomic operations). Research language; no commits since ~2022.
+* [LLLL](https://github.com/mmalvarez/eth-isabelle/blob/master/example/LLLL.thy)
+    - An LLL-like compiler implemented in Isabelle/HOL. The parent repo has been abandoned since ~2020.
+* [HAseembly-evm](https://github.com/takenobu-hs/haskell-ethereum-assembly)
+    - An EVM assembly implemented as a Haskell DSL. Abandoned since ~2018.
+* [Bamboo](https://github.com/pirapira/bamboo) (experimental)
+    - A language without loops but with explicit constructor invocation at the end of every call. Abandoned since ~2022.
+
+### Languages that Compile zk-SNARK Circuits and Proofs
+
+* [jsnark](https://github.com/akosba/jsnark)
+    - A Java front-end for writing R1CS SNARKs. No commits since ~2022.
+
+---
+
+## Debuggers (Stale)
+
+* [debug\_traceTransaction (go-ethereum wiki)](https://github.com/ethereum/go-ethereum/wiki/Management-APIs#debug_tracetransaction)
+    - The go-ethereum GitHub wiki is a legacy resource; documentation has moved to [geth.ethereum.org](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug).
+* [Dr. Y's Ethereum Contract Analyzer](http://dry.yoichihirai.com/)
+    - A symbolic executor for EVM code. Domain no longer exists (DNS NXDOMAIN).
+
+---
+
+## Code Analyzers (Stale)
+
+* [porosity](https://github.com/msuiche/porosity)
+    - A reverse engineering tool, disassembler, ABI function detector and decompiler that also highlights vulnerabilities. Abandoned since ~2019.
+* [evmdis](https://github.com/arachnid/evmdis)
+    - A disassembler for EVM code. Abandoned since ~2022.
+* [ethersplay](https://github.com/crytic/ethersplay)
+    - Officially archived. An EVM plugin for [Binary Ninja](https://binary.ninja/).
+* [Oyente](https://github.com/enzymefinance/oyente)
+    - Officially archived (under enzymefinance after Melon Protocol rebrand). An automatic EVM code analyzer based on symbolic execution and Z3 SMT solver.
+
+---
+
+## Improvement Proposals (Stale)
+
+* [EVM 1.5](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-615.md)
+    - A proposal to tame jumps so that a linear-time scan can determine stack layouts. EIP-615 has **Stagnant** status and was never advanced.
+* [eWASM](https://github.com/ewasm)
+    - A proposal to use [WebAssembly](http://webassembly.org/) for Ethereum contract execution. Superseded by other EVM evolution efforts; all repos effectively abandoned since ~2022.
+
+---
+
+## Related Resources (Stale)
+
+* Awesome Ethereum (`http://awesome-ethereum.com/`)
+    - Domain has been taken over by an unrelated website. The original content no longer exists.


### PR DESCRIPTION
## Summary

- **Create `STALE.md`** to preserve historical resources that are now archived, abandoned, or pointing at dead domains — moved out of the main README rather than deleted outright
- **Fix 10 URLs** that still point to active projects but have moved to new canonical locations (Vyper, ZoKrates, Echidna, Mythril, hevm, EthereumJS, KEVM, Remix, Securify, geth debug docs)
- **Remove fully dead links** where the domain/page no longer exists (awesome-ethereum.com, dry.yoichihirai.com gone, hackernoon article removed, MIT SICP URL 403)

### Moved to STALE.md (~20 entries)

**EVM Implementations:** Parity, cpp-ethereum/aleth, Pyethereum, Py-EVM, EthereumJ, SputnikVM, dapphub/hevm, eth-isabelle, Burrow, ruby-ethereum, sputter, solevm, eth-acl2, mana

**Languages:** Pyramid Scheme, Flint, LLLL, HAseembly-evm, Bamboo, jsnark

**Debuggers:** go-ethereum wiki URL, Dr. Y's Contract Analyzer

**Code Analyzers:** porosity, evmdis, ethersplay, Oyente

**Improvement Proposals:** EVM 1.5 (EIP-615, Stagnant), eWASM (abandoned)

**Related Resources:** awesome-ethereum.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)